### PR TITLE
fix: A rajzolás rögtön megjelenik PIXI.Ticker() segítségével

### DIFF
--- a/src/frontend/components/editing/imageWorkPlace.tsx
+++ b/src/frontend/components/editing/imageWorkPlace.tsx
@@ -23,12 +23,14 @@ export default function ImageWorkPlace() {
     maskBrushSize,
     maskErase,
     brushRef,
-    renderTextureRef,
+    maskTextureRef,
     maskContainerRef,
     maskSharpness,
     selectedLayer,
     spriteRef,
-    webglFilterRef
+    webglFilterRef,
+    isDrawing,
+    setIsDrawing
   } = useWorkSession();
 
   const { setCropBox, setTextPosition, setTextRelativePosition } =
@@ -39,7 +41,6 @@ export default function ImageWorkPlace() {
   );
 
   const [draggableText, setDraggable] = useState<string | null>(null);
-  const [isDrawing, setIsDrawing] = useState<boolean>(false);
   const lastX = useRef<number | null>(null);
   const lastY = useRef<number | null>(null);
 
@@ -110,7 +111,7 @@ export default function ImageWorkPlace() {
     maskErase,
     maskContainer,
     brushRef,
-    renderTextureRef,
+    maskTextureRef,
     sharpness: maskSharpness,
     selectedLayer,
     scale: cropboxScale,

--- a/src/frontend/components/editing/imageWorkPlace.tsx
+++ b/src/frontend/components/editing/imageWorkPlace.tsx
@@ -24,13 +24,14 @@ export default function ImageWorkPlace() {
     maskErase,
     brushRef,
     maskTextureRef,
-    maskContainerRef,
     maskSharpness,
     selectedLayer,
     spriteRef,
     webglFilterRef,
     isDrawing,
-    setIsDrawing
+    setIsDrawing,
+    renderSpriteRef,
+    textureRef,
   } = useWorkSession();
 
   const { setCropBox, setTextPosition, setTextRelativePosition } =
@@ -55,7 +56,6 @@ export default function ImageWorkPlace() {
   const imgH = image?.dimesions?.height ?? 1;
   const masks = image?.masks;
   const brushSize = maskBrushSize;
-  const maskContainer = maskContainerRef.current;
   const cropboxScale = Math.min(
     (canvasRef.current?.clientWidth ?? 0) / imgW,
     (canvasRef.current?.clientHeight ?? 0) / imgH,
@@ -109,7 +109,6 @@ export default function ImageWorkPlace() {
     isDrawing,
     setIsDrawing,
     maskErase,
-    maskContainer,
     brushRef,
     maskTextureRef,
     sharpness: maskSharpness,
@@ -118,6 +117,7 @@ export default function ImageWorkPlace() {
     spriteRef,
     webglFilterRef,
     renderTextures,
+    textureRef,
   });
 
   const canvasH = canvasRef.current?.clientHeight ?? 1080;

--- a/src/frontend/components/editing/imageWorkPlace.tsx
+++ b/src/frontend/components/editing/imageWorkPlace.tsx
@@ -27,7 +27,8 @@ export default function ImageWorkPlace() {
     maskContainerRef,
     maskSharpness,
     selectedLayer,
-    spriteRef
+    spriteRef,
+    webglFilterRef
   } = useWorkSession();
 
   const { setCropBox, setTextPosition, setTextRelativePosition } =
@@ -43,6 +44,7 @@ export default function ImageWorkPlace() {
   const lastY = useRef<number | null>(null);
 
   const box = image?.box;
+  const renderTextures = image?.renderTextures;
   const expandMode = image?.expandMode;
   const copyrightImage = image?.copyrightImage;
   const texts = image?.texts ?? [];
@@ -113,6 +115,8 @@ export default function ImageWorkPlace() {
     selectedLayer,
     scale: cropboxScale,
     spriteRef,
+    webglFilterRef,
+    renderTextures
   });
 
   const canvasH = canvasRef.current?.clientHeight ?? 1080;

--- a/src/frontend/components/editing/imageWorkPlace.tsx
+++ b/src/frontend/components/editing/imageWorkPlace.tsx
@@ -30,23 +30,21 @@ export default function ImageWorkPlace() {
     webglFilterRef,
     isDrawing,
     setIsDrawing,
-    renderSpriteRef,
     textureRef,
   } = useWorkSession();
 
   const { setCropBox, setTextPosition, setTextRelativePosition } =
     useSessionStore();
 
-  const image = useSessionStore((state) =>
-    state.sessionData.find((si) => si.id === selectedImg),
-  );
+  let image = useSessionStore
+    .getState()
+    .sessionData.find((si) => si.id === selectedImg);
 
   const [draggableText, setDraggable] = useState<string | null>(null);
   const lastX = useRef<number | null>(null);
   const lastY = useRef<number | null>(null);
 
   const box = image?.box;
-  const renderTextures = image?.renderTextures;
   const expandMode = image?.expandMode;
   const copyrightImage = image?.copyrightImage;
   const texts = image?.texts ?? [];
@@ -54,8 +52,6 @@ export default function ImageWorkPlace() {
   const borderSize = image?.borderSize;
   const imgW = image?.dimesions?.width ?? 1;
   const imgH = image?.dimesions?.height ?? 1;
-  const masks = image?.masks;
-  const brushSize = maskBrushSize;
   const cropboxScale = Math.min(
     (canvasRef.current?.clientWidth ?? 0) / imgW,
     (canvasRef.current?.clientHeight ?? 0) / imgH,
@@ -100,11 +96,10 @@ export default function ImageWorkPlace() {
 
   createMask({
     appRef,
-    brushSize,
+    brushSize: maskBrushSize,
     hoverMaskGraphRef,
     lastX,
     lastY,
-    masks,
     selectedImg,
     isDrawing,
     setIsDrawing,
@@ -116,8 +111,8 @@ export default function ImageWorkPlace() {
     scale: cropboxScale,
     spriteRef,
     webglFilterRef,
-    renderTextures,
     textureRef,
+    image,
   });
 
   const canvasH = canvasRef.current?.clientHeight ?? 1080;

--- a/src/frontend/components/editing/imageWorkPlace.tsx
+++ b/src/frontend/components/editing/imageWorkPlace.tsx
@@ -116,7 +116,7 @@ export default function ImageWorkPlace() {
     scale: cropboxScale,
     spriteRef,
     webglFilterRef,
-    renderTextures
+    renderTextures,
   });
 
   const canvasH = canvasRef.current?.clientHeight ?? 1080;

--- a/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
+++ b/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
@@ -92,7 +92,6 @@ export default function ExportDrawer() {
               }),
             );
 
-            //TODO: Az a baj, hogy a haldSprite nem az egész  hanem csak ahogy rajzolva van a maszk ugy (mert ugye a képből vesszük ki)
             masksImageHalds.push(
               await appRef.current.renderer.extract.base64({
                 target: imageMask.haldSprite,

--- a/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
+++ b/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
@@ -84,7 +84,7 @@ export default function ExportDrawer() {
         for (const imageMask of imageMasks) {
           masksImages.push(
             await appRef.current.renderer.extract.base64({
-              target: imageMask.sprite,
+              target: imageMask.resultTexture,
               format: "png",
               resolution: 1,
             }),
@@ -285,7 +285,7 @@ export default function ExportDrawer() {
     if (masksImages.length > 0) {
       for (let index = 0; index < masksImages.length; index++) {
         const mask = masksImages[index];
-        console.log(mask);
+
         const maskFile = new File([mask], `mask_${index}`);
         formData.append(`masks_files`, maskFile, `mask_${index}.png`);
       }

--- a/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
+++ b/src/frontend/components/editing/layout/exportDrawer/exportDrawer.tsx
@@ -31,6 +31,7 @@ import {
   XPositions,
   YPositions,
 } from "@/interfaces/interface";
+import PIXI, { Sprite } from "pixi.js";
 
 export default function ExportDrawer() {
   const images = useSessionStore((s) => s.sessionData);
@@ -80,23 +81,25 @@ export default function ExportDrawer() {
 
       const imageMasks = selectedImage.renderTextures;
 
-      if (imageMasks && imageMasks.length > 0 && appRef.current) {
-        for (const imageMask of imageMasks) {
-          masksImages.push(
-            await appRef.current.renderer.extract.base64({
-              target: imageMask.resultTexture,
-              format: "png",
-              resolution: 1,
-            }),
-          );
+      
+        if (imageMasks && imageMasks.length > 0 && appRef.current) {
+          for (const imageMask of imageMasks) {
+            masksImages.push(
+              await appRef.current.renderer.extract.base64({
+                target: imageMask.maskTexture,
+                format: "png",
+                resolution: 1,
+              }),
+            );
 
-          masksImageHalds.push(
-            await appRef.current.renderer.extract.base64({
-              target: imageMask.haldSprite,
-              format: "png",
-              resolution: 1,
-            }),
-          );
+            //TODO: Az a baj, hogy a haldSprite nem az egész  hanem csak ahogy rajzolva van a maszk ugy (mert ugye a képből vesszük ki)
+            masksImageHalds.push(
+              await appRef.current.renderer.extract.base64({
+                target: imageMask.haldSprite,
+                format: "png",
+                resolution: 1,
+              }),
+            );
         }
       }
     }

--- a/src/frontend/components/editing/layout/sidebar.tsx
+++ b/src/frontend/components/editing/layout/sidebar.tsx
@@ -133,6 +133,7 @@ const sidebarElements = (
           },
           onChange: (e: SliderValueChangeDetails) => {
             uniforms.brightness_input = Number(e.value) / 100.0;
+            console.log(uniforms);
           },
           clearFunc: () => {
             uniforms.brightness_input = 0;
@@ -819,7 +820,6 @@ export default function SideBar() {
     .getState()
     .sessionData.find((si) => si.id === selectedImg);
 
-  const selectedExtension = image?.exportSettings?.fileExtension;
   const filters =
     selectedLayer !== null
       ? useSessionStore.getState().getFilters(selectedImg, selectedLayer)

--- a/src/frontend/components/editing/layout/sidebar.tsx
+++ b/src/frontend/components/editing/layout/sidebar.tsx
@@ -133,7 +133,6 @@ const sidebarElements = (
           },
           onChange: (e: SliderValueChangeDetails) => {
             uniforms.brightness_input = Number(e.value) / 100.0;
-            console.log(uniforms);
           },
           clearFunc: () => {
             uniforms.brightness_input = 0;

--- a/src/frontend/components/editing/layout/sidebar.tsx
+++ b/src/frontend/components/editing/layout/sidebar.tsx
@@ -71,6 +71,7 @@ const sidebarElements = (
 ) => {
   const activeLayerObj =
     selectedLayer !== null ? image?.renderTextures?.[selectedLayer] : null;
+
   const activeFilter = activeLayerObj
     ? activeLayerObj.filter
     : webglFilterRef?.current;
@@ -80,7 +81,7 @@ const sidebarElements = (
   return [
     {
       function: "Kép szöveg",
-      hide: image.captionSamples.length <= 0,
+      hide: image.captionSamples.length <= 0 || selectedLayer !== null,
       icon: <LuTag />,
       inputs: [
         {
@@ -93,6 +94,7 @@ const sidebarElements = (
     {
       function: "Maszkolás",
       icon: <LuVenetianMask />,
+      hide: selectedLayer === null,
       inputs: [
         {
           name: "",
@@ -104,6 +106,7 @@ const sidebarElements = (
     {
       function: "LUT",
       icon: <TbColorSwatch />,
+      hide: selectedLayer !== null,
       inputs: [
         {
           name: "",
@@ -672,6 +675,7 @@ const sidebarElements = (
     {
       function: "Szövegek",
       icon: <LuType />,
+      hide: selectedLayer !== null,
       inputs: [
         {
           name: "",
@@ -683,6 +687,7 @@ const sidebarElements = (
     {
       function: "Overlay kép",
       icon: <LuImages />,
+      hide: selectedLayer !== null,
       inputs: [
         {
           name: "",
@@ -694,6 +699,7 @@ const sidebarElements = (
     {
       function: "Képkeret",
       icon: <LuFrame />,
+      hide: selectedLayer !== null,
       inputs: [
         {
           name: "Képkeret méret",
@@ -780,6 +786,7 @@ const sidebarElements = (
     {
       function: "Méretezés",
       icon: <LuImageUpscale />,
+      hide: selectedLayer !== null,
       inputs: [
         {
           name: "",

--- a/src/frontend/components/editing/mask/layerBlock.tsx
+++ b/src/frontend/components/editing/mask/layerBlock.tsx
@@ -93,16 +93,14 @@ const LayersAccordion = () => {
   const { sessionData, addNewRenderTexture, deleteLayer } = useSessionStore();
   const {
     appRef,
-    renderTextureRef,
+    maskTextureRef,
     selectedImg,
     selectedLayer,
     setSelectLayer,
     textureRef,
     maskContainerRef,
-    selectedLayerRef,
     webglFilterRef,
     hoverMaskGraphRef,
-    spriteRef,
   } = useWorkSession();
 
   const image = sessionData.find((i) => i.id == selectedImg);
@@ -112,26 +110,24 @@ const LayersAccordion = () => {
     if (!textureRef.current || !maskContainerRef.current) return;
 
     let index = renderTextures?.length ?? 0;
+    const channelOffset = getChannelOffsets(filters);
 
     const layer = new Container();
     layer.label = `layer_${index}`;
 
     const size = image?.dimesions;
+    const renderSprite = new Sprite();
 
-    const renderTexture = RenderTexture.create({
-      height: size?.height,
+    const maskTexture = RenderTexture.create({
       width: size?.width,
+      height: size?.height,
     });
+    maskTextureRef.current = maskTexture;
 
-    const outputSprite = new Sprite(renderTexture);
-
-    const imageSprite = new Sprite(textureRef.current);
-    imageSprite.anchor.set(0.5);
-
-    selectedLayerRef.current = imageSprite;
-    renderTextureRef.current = renderTexture;
-
-    const channelOffset = getChannelOffsets(filters);
+    const resultTexture = RenderTexture.create({
+      width: size?.width,
+      height: size?.height,
+    });
 
     const filterUniforms = new UniformGroup({
       exposure_input: { value: filters.exposure / 5.0, type: "f32" },
@@ -164,30 +160,6 @@ const LayersAccordion = () => {
       vibrance_input: { value: filters.vibrance / 100.0, type: "f32" },
     });
 
-    //TODO: Márcsak azt kéne megoldani, hogy itt lerendelni a sprite-ot egy renderTextureban, majd minden uniforms változtatásnál le kell futtatni az összes layerre a rendert és az uniformson keresztüli átadást az új layerről
-    /*
-    Valahogy igy:
-    const rtA = RenderTexture.create(...);
-
-    let previous = rtA;
-    let current = rtB;
-
-    for (const layer of layers) {
-        filter.uniforms.prev_result = previous;
-        filter.uniforms.layer_mask = layer.maskTexture;
-
-        renderer.render(layer.sprite, {
-            renderTexture: current
-        });
-
-        [previous, current] = [current, previous];
-    }
-    */
-    const prevLayer =
-      index > 0
-        ? renderTextures?.find((rt) => rt.id === index - 1)?.mask.source
-        : spriteRef.current;
-
     const filter = Filter.from({
       gl: {
         fragment: allFiltersFragment,
@@ -195,16 +167,11 @@ const LayersAccordion = () => {
       },
       resources: {
         filterUniforms: filterUniforms,
-        layer_mask: renderTexture.source,
-        prev_result: prevLayer,
+        layer_mask: maskTexture.source,
       },
     });
 
     if (appRef.current) {
-      layer.addChild(outputSprite);
-      layer.addChild(imageSprite);
-
-      maskContainerRef.current.addChild(layer);
       maskContainerRef.current.zIndex = 10000;
 
       const hover = appRef.current.stage.getChildByLabel(
@@ -221,10 +188,10 @@ const LayersAccordion = () => {
 
     addNewRenderTexture(
       selectedImg,
-      renderTexture,
-      outputSprite,
-      imageSprite,
+      maskTexture,
       filter,
+      resultTexture,
+      renderSprite,
     );
 
     setSelectLayer(index);
@@ -232,7 +199,7 @@ const LayersAccordion = () => {
   }
 
   const activeLayer = renderTextures?.find(
-    (r) => r.mask == renderTextureRef.current,
+    (r) => r.maskTexture == maskTextureRef.current,
   );
 
   useEffect(() => {
@@ -242,8 +209,7 @@ const LayersAccordion = () => {
       const renderText =
         renderTextures && renderTextures?.find((i) => i.id === selectedLayer);
       if (renderText) {
-        renderTextureRef.current = renderText.mask;
-
+        maskTextureRef.current = renderText.maskTexture;
         webglFilterRef.current = renderText.filter;
       }
     }
@@ -306,10 +272,7 @@ const LayersAccordion = () => {
 
                           if (!appRef.current) return;
                           appRef.current.stage.removeChild(
-                            selectedLayer?.imageSprite,
-                          );
-                          appRef.current.stage.removeChild(
-                            selectedLayer?.sprite,
+                            selectedLayer?.resultTexture,
                           );
 
                           setSelectLayer(null);

--- a/src/frontend/components/editing/mask/layerBlock.tsx
+++ b/src/frontend/components/editing/mask/layerBlock.tsx
@@ -121,6 +121,7 @@ const LayersAccordion = () => {
       height: size?.height,
       width: size?.width,
     });
+
     const outputSprite = new Sprite(renderTexture);
 
     const imageSprite = new Sprite(textureRef.current);

--- a/src/frontend/components/editing/mask/layerBlock.tsx
+++ b/src/frontend/components/editing/mask/layerBlock.tsx
@@ -15,6 +15,7 @@ import {
   Container,
   defaultFilterVert,
   Filter,
+  Graphics,
   RenderTexture,
   Sprite,
   UniformGroup,
@@ -106,26 +107,6 @@ const LayersAccordion = () => {
   const image = sessionData.find((i) => i.id == selectedImg);
   const renderTextures = image?.renderTextures;
 
-// TODO: Layeres adjustment ötletem
-// Minden adjustment egy külön layer lesz.
-//
-// Layer 0 mindig létezik:
-// mask = teljesen fehér
-// settings = a global adjustment
-//
-// Layer 1..N:
-// mask = felhasználó által rajzolt maszk
-// settings = az adott layer adjustment
-//
-//
-// current = originalImage
-//filtered = applyAdjustments(current, layerSettings);
-//current = mix(current, filtered, layerMask);
-//
-// return current;
-//
-// Így minden layer ugyanazt a shadert használja,
-// csak a maszk és a filter beállításai változnak. 
   function createNew() {
     if (!textureRef.current || !maskContainerRef.current) return;
 
@@ -133,7 +114,6 @@ const LayersAccordion = () => {
 
     const layer = new Container();
     layer.label = `layer_${index}`;
-
 
     const size = image?.dimesions;
 
@@ -144,14 +124,10 @@ const LayersAccordion = () => {
     const outputSprite = new Sprite(renderTexture);
 
     const imageSprite = new Sprite(textureRef.current);
-    maskContainerRef.current.addChild(imageSprite);
     imageSprite.anchor.set(0.5);
-    imageSprite.mask = outputSprite;
 
     selectedLayerRef.current = imageSprite;
     renderTextureRef.current = renderTexture;
-
-    setSelectLayer(null);
 
     const channelOffset = getChannelOffsets(filters);
 
@@ -186,6 +162,13 @@ const LayersAccordion = () => {
       vibrance_input: { value: filters.vibrance / 100.0, type: "f32" },
     });
 
+    const prevLayer =
+      index > 0
+        ? renderTextures?.find((rt) => rt.id === index - 1)?.mask.source
+        : image &&
+          image.renderTexture &&
+          (image.renderTexture as RenderTexture).source;
+
     const filter = Filter.from({
       gl: {
         fragment: allFiltersFragment,
@@ -193,16 +176,16 @@ const LayersAccordion = () => {
       },
       resources: {
         filterUniforms: filterUniforms,
+        layer_mask: renderTexture.source,
+        prev_result: prevLayer,
       },
     });
 
     if (appRef.current) {
       layer.addChild(outputSprite);
       layer.addChild(imageSprite);
-      maskContainerRef.current.addChild(layer);
 
-      if (!appRef.current.stage.getChildByLabel("maskContainer"))
-        appRef.current.stage.addChild(maskContainerRef.current);
+      maskContainerRef.current.addChild(layer);
 
       const hover = appRef.current.stage.getChildByLabel(
         hoverMaskGraphRef.current.label,

--- a/src/frontend/components/editing/mask/layerBlock.tsx
+++ b/src/frontend/components/editing/mask/layerBlock.tsx
@@ -102,6 +102,7 @@ const LayersAccordion = () => {
     selectedLayerRef,
     webglFilterRef,
     hoverMaskGraphRef,
+    spriteRef,
   } = useWorkSession();
 
   const image = sessionData.find((i) => i.id == selectedImg);
@@ -163,12 +164,29 @@ const LayersAccordion = () => {
       vibrance_input: { value: filters.vibrance / 100.0, type: "f32" },
     });
 
+    //TODO: Márcsak azt kéne megoldani, hogy itt lerendelni a sprite-ot egy renderTextureban, majd minden uniforms változtatásnál le kell futtatni az összes layerre a rendert és az uniformson keresztüli átadást az új layerről
+    /*
+    Valahogy igy:
+    const rtA = RenderTexture.create(...);
+
+    let previous = rtA;
+    let current = rtB;
+
+    for (const layer of layers) {
+        filter.uniforms.prev_result = previous;
+        filter.uniforms.layer_mask = layer.maskTexture;
+
+        renderer.render(layer.sprite, {
+            renderTexture: current
+        });
+
+        [previous, current] = [current, previous];
+    }
+    */
     const prevLayer =
       index > 0
         ? renderTextures?.find((rt) => rt.id === index - 1)?.mask.source
-        : image &&
-          image.renderTexture &&
-          (image.renderTexture as RenderTexture).source;
+        : spriteRef.current;
 
     const filter = Filter.from({
       gl: {
@@ -187,6 +205,7 @@ const LayersAccordion = () => {
       layer.addChild(imageSprite);
 
       maskContainerRef.current.addChild(layer);
+      maskContainerRef.current.zIndex = 10000;
 
       const hover = appRef.current.stage.getChildByLabel(
         hoverMaskGraphRef.current.label,

--- a/src/frontend/components/editing/mask/layerBlock.tsx
+++ b/src/frontend/components/editing/mask/layerBlock.tsx
@@ -23,6 +23,7 @@ import {
 import { allFiltersFragment } from "@/handlers/filters/allFiltersFragment";
 import { getChannelOffsets } from "@/helper/lut/getChannelOffset";
 import { filters } from "@/interfaces/filters.interface";
+import { maskFiltersFragment } from "@/handlers/filters/maskFiltersFragment";
 
 //#region SIDEBAR ITEM
 export const MaskLayerBlock = () => {
@@ -98,7 +99,6 @@ const LayersAccordion = () => {
     selectedLayer,
     setSelectLayer,
     textureRef,
-    maskContainerRef,
     webglFilterRef,
     hoverMaskGraphRef,
   } = useWorkSession();
@@ -107,7 +107,7 @@ const LayersAccordion = () => {
   const renderTextures = image?.renderTextures;
 
   function createNew() {
-    if (!textureRef.current || !maskContainerRef.current) return;
+    if (!textureRef.current) return;
 
     let index = renderTextures?.length ?? 0;
     const channelOffset = getChannelOffsets(filters);
@@ -171,9 +171,17 @@ const LayersAccordion = () => {
       },
     });
 
-    if (appRef.current) {
-      maskContainerRef.current.zIndex = 10000;
+     const filterMask = Filter.from({
+      gl: {
+        fragment: maskFiltersFragment,
+        vertex: defaultFilterVert,
+      },
+      resources: {
+        filterUniforms: filterUniforms,
+      },
+    });
 
+    if (appRef.current) {
       const hover = appRef.current.stage.getChildByLabel(
         hoverMaskGraphRef.current.label,
       );
@@ -192,6 +200,7 @@ const LayersAccordion = () => {
       filter,
       resultTexture,
       renderSprite,
+      filterMask
     );
 
     setSelectLayer(index);

--- a/src/frontend/components/webGlComponent.tsx
+++ b/src/frontend/components/webGlComponent.tsx
@@ -1,6 +1,7 @@
 //TODO: Refaktorálás
 import { allFiltersFragment } from "@/handlers/filters/allFiltersFragment";
 import { getChannelOffsets } from "@/helper/lut/getChannelOffset";
+import { applyFilters } from "@/helper/mask/applyFilters";
 import { calcScale } from "@/helper/sizes/calcScale";
 import { filters } from "@/interfaces/filters.interface";
 import { useWorkSession } from "@/providers/sessionprovider";
@@ -42,6 +43,7 @@ export default function WebGlComponent() {
     webglFilterRef,
     renderSpriteRef,
     selectedLayer,
+    isDrawing,
   } = useWorkSession();
   const { sessionData, setImageSize, setRenderTexture, setFilter } =
     useSessionStore();
@@ -51,11 +53,6 @@ export default function WebGlComponent() {
   const lutFilter = useSessionStore(
     (state) =>
       state.sessionData.find((img) => img.id === selectedImg)?.lutFilter,
-  );
-
-  const layers = useSessionStore(
-    (state) =>
-      state.sessionData.find((img) => img.id === selectedImg)?.renderTextures,
   );
 
   //! shallow: nem generál le újra az objektumot hanem mintha cachelte volna mindig az adott objektumot irja felül / ÖSSZEHASONLÍT
@@ -71,7 +68,6 @@ export default function WebGlComponent() {
   const box = image?.box;
   const cropSaved = image?.cropSave;
   const expandPadding = image?.expandSize?.padding;
-  const haldSprite = image?.haldSprite;
 
   async function initApp() {
     const app = new Application();
@@ -228,7 +224,13 @@ export default function WebGlComponent() {
         canvasRef.current.replaceChildren(appRef.current.canvas);
 
       updateLayout();
-      applyFilters();
+      applyFilters({
+        image,
+        textureRef,
+        renderSpriteRef,
+        appRef,
+        spriteRef,
+      });
       setSelectLayer(null);
       createFirstLayer(5000, 5000);
     };
@@ -276,58 +278,6 @@ export default function WebGlComponent() {
       loadImage();
     }
   }, [expandMode, cropSaved]);
-
-  function applyFilters(startIndex = 0) {
-    if (!appRef.current) return;
-
-    const imageFilter = image?.filter;
-
-    if (spriteRef.current && imageFilter && haldSprite) {
-      spriteRef.current.filters = lutFilter
-        ? [lutFilter, imageFilter]
-        : [imageFilter];
-      haldSprite.filters = lutFilter ? [lutFilter, imageFilter] : [imageFilter];
-    }
-
-    if (
-      image &&
-      image.renderTextures &&
-      image.renderTextures.length > 0 &&
-      spriteRef.current
-    ) {
-      let input =
-        startIndex === 0
-          ? textureRef.current
-          : image.renderTextures[startIndex - 1].resultTexture;
-
-      const layers = image.renderTextures;
-
-      for (let i = startIndex; i < layers.length; i++) {
-        const layer = image.renderTextures[i];
-
-        if (spriteRef.current) {
-          renderSpriteRef.current.texture = input;
-
-          if (layer.filter && appRef.current) {
-            layer.haldSprite.filters = [layer.filterMask];
-            layer.filter.resources.layer_mask = layer.maskTexture.source;
-            renderSpriteRef.current.filters = [layer.filter];
-
-            appRef.current.renderer.render({
-              container: renderSpriteRef.current,
-              target: layer.resultTexture,
-              clear: true,
-            });
-
-            input = layer.resultTexture;
-          }
-        }
-      }
-
-      spriteRef.current.texture = input;
-      spriteRef.current.filters = [];
-    }
-  }
 
   const updateLayout = () => {
     if (
@@ -410,8 +360,13 @@ export default function WebGlComponent() {
         },
       });
 
-      applyFilters();
-
+      applyFilters({
+        image,
+        textureRef,
+        renderSpriteRef,
+        appRef,
+        spriteRef,
+      });
       return;
     } else {
       const scale = Math.min(areaH / imgH, areaW / imgW);
@@ -600,7 +555,13 @@ export default function WebGlComponent() {
         });
       }
 
-      applyFilters();
+      applyFilters({
+        image,
+        textureRef,
+        renderSpriteRef,
+        appRef,
+        spriteRef,
+      });
     }
   };
 
@@ -616,10 +577,52 @@ export default function WebGlComponent() {
     cropSaved,
     borderSize,
     lutFilter,
-    layers,
   ]);
 
-  applyFilters();
+  applyFilters({
+    image,
+    textureRef,
+    renderSpriteRef,
+    appRef,
+    spriteRef,
+  });
+
+  //! Tickert használunk, mert ez azt csinálja hogy "tick"-enként (frissítési ciklusonként / framenként)
+  //! futtatja a filter frissítését a megadott sprite-tól kezdve. Ez azért előnyös, mert mindig csak azokat az elemeket frissítjük, amelyeknek szükségük van rá.
+
+  //! Ez performance szempontból jó, mert mikor rajzolunk, akkor alapból ha rajzoláshoz kötnénk az applyFilter()-t, akkor létrejönne mondjuk 1000 iteráció, 
+  //! viszont ezzel nem minden iterációkor futtatjuk le az applyFilter()-t, hanem minden egyes tick-nél
+  useEffect(() => {
+    if (!appRef.current) return;
+
+    const update = () => {
+      applyFilters({
+        renderSpriteRef,
+        spriteRef,
+        startIndex: selectedLayer ?? 0,
+        image,
+        appRef,
+        textureRef,
+      });
+    };
+
+    appRef.current.ticker.add(update);
+
+    return () => {
+      appRef.current?.ticker.remove(update);
+    };
+  }, [renderSpriteRef, spriteRef, selectedLayer, image, appRef, textureRef]);
+
+  useEffect(() => {
+    applyFilters({
+      image,
+      textureRef,
+      renderSpriteRef,
+      appRef,
+      spriteRef,
+      startIndex: selectedLayer ?? 0,
+    });
+  }, [isDrawing]);
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/frontend/components/webGlComponent.tsx
+++ b/src/frontend/components/webGlComponent.tsx
@@ -42,7 +42,7 @@ export default function WebGlComponent() {
     setSelectLayer,
     webglFilterRef,
   } = useWorkSession();
-  const { sessionData, setImageSize,setRenderTexture } = useSessionStore();
+  const { sessionData, setImageSize,setRenderTexture, setFilter } = useSessionStore();
 
   const filtersRef = useRef<Container | null>(null);
 
@@ -169,8 +169,8 @@ export default function WebGlComponent() {
       },
       resources: {
         filterUniforms: filterUniforms,
-        layer_mask: renderTexture.source,
-        prev_result: textureRef.current.source,
+        layer_mask: renderTextureRef.current.source,
+        prev_result: imageSprite.texture.source,
       },
     });
 
@@ -182,6 +182,7 @@ export default function WebGlComponent() {
 
     webglFilterRef.current = filter;
     setRenderTexture(selectedImg, renderTextureRef.current);
+    setFilter(selectedImg, filter);
 
     appRef.current.renderer.render({
       container: fill,
@@ -234,7 +235,7 @@ export default function WebGlComponent() {
       const brush = new Graphics();
 
       if (!appRef.current.stage.getChildByLabel("maskContainer"))
-        appRef.current.stage.addChild(maskContainer);
+        appRef.current.stage.addChildAt(maskContainer,0);
 
       maskContainerRef.current = maskContainer;
 

--- a/src/frontend/components/webGlComponent.tsx
+++ b/src/frontend/components/webGlComponent.tsx
@@ -1,5 +1,8 @@
 //TODO: Refaktorálás
+import { allFiltersFragment } from "@/handlers/filters/allFiltersFragment";
+import { getChannelOffsets } from "@/helper/lut/getChannelOffset";
 import { calcScale } from "@/helper/sizes/calcScale";
+import { filters } from "@/interfaces/filters.interface";
 import { useWorkSession } from "@/providers/sessionprovider";
 import { useSessionStore } from "@/stores/sessionData";
 import { Box, parseColor } from "@chakra-ui/react";
@@ -7,11 +10,15 @@ import "pixi-filters";
 import {
   Application,
   Container,
+  defaultFilterVert,
+  Filter,
   Graphics,
   ImageSource,
   Rectangle,
+  RenderTexture,
   Sprite,
   Texture,
+  UniformGroup,
 } from "pixi.js";
 import { useEffect, useRef } from "react";
 
@@ -33,8 +40,9 @@ export default function WebGlComponent() {
     maskContainerRef,
     selectedLayerRef,
     setSelectLayer,
+    webglFilterRef,
   } = useWorkSession();
-  const { sessionData, setImageSize } = useSessionStore();
+  const { sessionData, setImageSize,setRenderTexture } = useSessionStore();
 
   const filtersRef = useRef<Container | null>(null);
 
@@ -91,6 +99,97 @@ export default function WebGlComponent() {
     })();
   }, []);
 
+  function createFirstLayer(w: number, h: number) {
+    if (!textureRef.current || !appRef.current || !maskContainerRef.current)
+      return;
+
+    const layer = new Container();
+    layer.label = `defaultImageLayer`;
+
+    const renderTexture = RenderTexture.create({
+      height: h,
+      width: w,
+    });
+    const outputSprite = new Sprite(renderTexture);
+
+    const imageSprite = new Sprite(textureRef.current);
+    maskContainerRef.current.addChild(imageSprite);
+    imageSprite.anchor.set(0.5);
+
+    const fill = new Graphics();
+
+    fill.rect(0, 0, w, h).fill({
+      color: "#fff",
+    });
+
+    layer.addChild(fill);
+
+    selectedLayerRef.current = imageSprite;
+    renderTextureRef.current = renderTexture;
+
+    setSelectLayer(null);
+
+    const channelOffset = getChannelOffsets(filters);
+
+    const filterUniforms = new UniformGroup({
+      exposure_input: { value: filters.exposure / 5.0, type: "f32" },
+      brightness_input: { value: filters.brightness / 100.0, type: "f32" },
+      contrast_input: {
+        value: (filters.contrast / 100.0) * 0.5 + 1.0,
+        type: "f32",
+      },
+      temperature_input: {
+        value: filters.temperature / 100.0,
+        type: "f32",
+      },
+      tint_input: { value: filters.tint / 100.0, type: "f32" },
+      saturation_input: { value: filters.saturation, type: "f32" },
+      hue_input: { value: filters.hue / 180.0, type: "f32" },
+      value_input: { value: filters.value, type: "f32" },
+      black_input: { value: filters.black / 255.0, type: "f32" },
+      white_input: { value: filters.white / 255.0, type: "f32" },
+      outblack_input: { value: filters.outblack / 255.0, type: "f32" },
+      outwhite_input: { value: filters.outwhite / 255.0, type: "f32" },
+      gamma_input: { value: filters.gamma, type: "f32" },
+      channel_colorMatrix_input: {
+        value: channelOffset.channels,
+        type: "mat3x3<f32>",
+      },
+      channel_offset_input: {
+        value: channelOffset.offset,
+        type: "vec3<f32>",
+      },
+      vibrance_input: { value: filters.vibrance / 100.0, type: "f32" },
+    });
+
+    const filter = Filter.from({
+      gl: {
+        fragment: allFiltersFragment,
+        vertex: defaultFilterVert,
+      },
+      resources: {
+        filterUniforms: filterUniforms,
+        layer_mask: renderTexture.source,
+        prev_result: textureRef.current.source,
+      },
+    });
+
+    if (appRef.current) {
+      layer.addChild(outputSprite);
+      layer.addChild(imageSprite);
+      maskContainerRef.current.addChild(layer);
+    }
+
+    webglFilterRef.current = filter;
+    setRenderTexture(selectedImg, renderTextureRef.current);
+
+    appRef.current.renderer.render({
+      container: fill,
+      target: renderTexture,
+      clear: false,
+    });
+  }
+
   async function loadImage() {
     if (!appRef.current) {
       return;
@@ -133,7 +232,10 @@ export default function WebGlComponent() {
       appRef.current.stage.addChild(hoverGraph);
 
       const brush = new Graphics();
-      maskContainer.addChild(brush);
+
+      if (!appRef.current.stage.getChildByLabel("maskContainer"))
+        appRef.current.stage.addChild(maskContainer);
+
       maskContainerRef.current = maskContainer;
 
       brushRef.current = brush;
@@ -148,6 +250,7 @@ export default function WebGlComponent() {
       updateLayout();
       applyFilters();
       setSelectLayer(null);
+      createFirstLayer(5000, 5000);
     };
 
     if (sessionData.length > 0 && sessionData[selectedImg].blob)
@@ -504,11 +607,15 @@ export default function WebGlComponent() {
           const sprite = rt.sprite;
 
           if (sprite && appRef.current && imageSprite && spriteRef.current) {
-            sprite.height =  (Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0);
-            sprite.width =  (Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0);
+            sprite.height =
+              Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0;
+            sprite.width =
+              Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0;
 
-            imageSprite.height = (Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0);
-            imageSprite.width = (Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0);
+            imageSprite.height =
+              Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0;
+            imageSprite.width =
+              Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0;
 
             sprite.anchor = 0;
             imageSprite.anchor = 0;

--- a/src/frontend/components/webGlComponent.tsx
+++ b/src/frontend/components/webGlComponent.tsx
@@ -35,14 +35,17 @@ export default function WebGlComponent() {
     overlayRef,
     canvasRef,
     brushRef,
-    renderTextureRef,
+    maskTextureRef,
     hoverMaskGraphRef,
     maskContainerRef,
     selectedLayerRef,
     setSelectLayer,
     webglFilterRef,
+    renderSpriteRef,
+    isDrawing
   } = useWorkSession();
-  const { sessionData, setImageSize,setRenderTexture, setFilter } = useSessionStore();
+  const { sessionData, setImageSize, setRenderTexture, setFilter } =
+    useSessionStore();
 
   const filtersRef = useRef<Container | null>(null);
 
@@ -106,28 +109,17 @@ export default function WebGlComponent() {
     const layer = new Container();
     layer.label = `defaultImageLayer`;
 
-    const renderTexture = RenderTexture.create({
+    const maskTexture = RenderTexture.create({
       height: h,
       width: w,
     });
-    const outputSprite = new Sprite(renderTexture);
-
-    const imageSprite = new Sprite(textureRef.current);
-    maskContainerRef.current.addChild(imageSprite);
-    imageSprite.anchor.set(0.5);
+    maskTextureRef.current = maskTexture;
 
     const fill = new Graphics();
-
     fill.rect(0, 0, w, h).fill({
       color: "#fff",
     });
-
     layer.addChild(fill);
-
-    selectedLayerRef.current = imageSprite;
-    renderTextureRef.current = renderTexture;
-
-    setSelectLayer(null);
 
     const channelOffset = getChannelOffsets(filters);
 
@@ -169,24 +161,18 @@ export default function WebGlComponent() {
       },
       resources: {
         filterUniforms: filterUniforms,
-        layer_mask: renderTextureRef.current.source,
-        prev_result: imageSprite.texture.source,
+        layer_mask: maskTextureRef.current.source,
       },
     });
-
-    if (appRef.current) {
-      layer.addChild(outputSprite);
-      layer.addChild(imageSprite);
-      maskContainerRef.current.addChild(layer);
-    }
-
     webglFilterRef.current = filter;
-    setRenderTexture(selectedImg, renderTextureRef.current);
+
+    setRenderTexture(selectedImg, maskTextureRef.current);
     setFilter(selectedImg, filter);
+    setSelectLayer(null);
 
     appRef.current.renderer.render({
       container: fill,
-      target: renderTexture,
+      target: maskTexture,
       clear: false,
     });
   }
@@ -207,16 +193,17 @@ export default function WebGlComponent() {
       const hoverGraph = new Graphics();
 
       textureRef.current = texture;
-      const sprite = new Sprite(texture);
+      renderSpriteRef.current.texture = texture;
 
-      sprite.anchor.set(0.5);
+      const renderSprite = new Sprite(texture);
+      renderSprite.anchor.set(0.5);
 
       const prevStage = appRef.current.stage.children.filter(
-        (fs) => fs !== sprite,
+        (fs) => fs !== renderSprite,
       )[0];
 
       if (prevStage) appRef.current.stage.removeChild(prevStage);
-      appRef.current.stage.addChild(sprite);
+      appRef.current.stage.addChild(renderSprite);
       appRef.current.stage.addChild(overlay);
 
       const maskContainer = new Container();
@@ -228,20 +215,16 @@ export default function WebGlComponent() {
 
       if (!image) return;
 
-      renderTextureRef.current = image.renderTexture;
+      maskTextureRef.current = image.renderTexture;
 
       appRef.current.stage.addChild(hoverGraph);
 
       const brush = new Graphics();
 
-      if (!appRef.current.stage.getChildByLabel("maskContainer"))
-        appRef.current.stage.addChildAt(maskContainer,0);
-
       maskContainerRef.current = maskContainer;
-
       brushRef.current = brush;
 
-      spriteRef.current = sprite;
+      spriteRef.current = renderSprite;
       overlayRef.current = overlay;
       hoverMaskGraphRef.current = hoverGraph;
 
@@ -302,33 +285,45 @@ export default function WebGlComponent() {
     if (!appRef.current) return;
 
     const imageFilter = image?.filter;
+    let imageMaskLayers = image?.renderTextures;
 
-    if (spriteRef.current && imageFilter) {
+    if (spriteRef.current && imageFilter && haldSprite) {
       spriteRef.current.filters = lutFilter
         ? [lutFilter, imageFilter]
         : [imageFilter];
-    }
-
-    if (haldSprite && imageFilter) {
       haldSprite.filters = lutFilter ? [lutFilter, imageFilter] : [imageFilter];
     }
 
-    let imageMaskLayers = image?.renderTextures;
-    imageMaskLayers?.forEach((layer) => {
-      const layerFilter = layer?.filter;
+    if (
+      image &&
+      image.renderTextures &&
+      image.renderTextures.length > 0 &&
+      spriteRef.current
+    ) {
+      let input = textureRef.current ?? spriteRef.current.texture;
 
-      if (layer.imageSprite && layerFilter) {
-        layer.imageSprite.filters = lutFilter
-          ? [lutFilter, layerFilter]
-          : [layerFilter];
-      }
+      imageMaskLayers?.forEach((layer) => {
+        if (spriteRef.current) {
+          renderSpriteRef.current.texture = input;
 
-      if (layer.haldSprite && layerFilter) {
-        layer.haldSprite.filters = lutFilter
-          ? [lutFilter, layerFilter]
-          : [layerFilter];
-      }
-    });
+          if (layer.filter && appRef.current) {
+            renderSpriteRef.current.filters = [layer.filter];
+            layer.filter.resources.layer_mask = layer.maskTexture.source;
+
+            appRef.current.renderer.render({
+              container: renderSpriteRef.current,
+              target: layer.resultTexture,
+              clear: true,
+            });
+
+            input = layer.resultTexture;
+          }
+        }
+      });
+
+      spriteRef.current.texture = input;
+      spriteRef.current.filters = [];
+    }
   }
 
   const updateLayout = () => {
@@ -602,34 +597,6 @@ export default function WebGlComponent() {
         });
       }
 
-      if (image?.renderTextures) {
-        image.renderTextures.forEach((rt) => {
-          const imageSprite = rt.imageSprite;
-          const sprite = rt.sprite;
-
-          if (sprite && appRef.current && imageSprite && spriteRef.current) {
-            sprite.height =
-              Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0;
-            sprite.width =
-              Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0;
-
-            imageSprite.height =
-              Number(appRef.current.canvas.style.height.replace("px", "")) ?? 0;
-            imageSprite.width =
-              Number(appRef.current.canvas.style.width.replace("px", "")) ?? 0;
-
-            sprite.anchor = 0;
-            imageSprite.anchor = 0;
-
-            sprite.x = 0;
-            sprite.y = 0;
-
-            imageSprite.x = 0;
-            imageSprite.y = 0;
-          }
-        });
-      }
-
       applyFilters();
     }
   };
@@ -648,6 +615,12 @@ export default function WebGlComponent() {
     lutFilter,
     layers,
   ]);
+
+  useEffect(()=>{
+    applyFilters();
+  },[
+    isDrawing
+  ])
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/frontend/components/webGlComponent.tsx
+++ b/src/frontend/components/webGlComponent.tsx
@@ -37,12 +37,11 @@ export default function WebGlComponent() {
     brushRef,
     maskTextureRef,
     hoverMaskGraphRef,
-    maskContainerRef,
     selectedLayerRef,
     setSelectLayer,
     webglFilterRef,
     renderSpriteRef,
-    isDrawing
+    selectedLayer,
   } = useWorkSession();
   const { sessionData, setImageSize, setRenderTexture, setFilter } =
     useSessionStore();
@@ -103,8 +102,7 @@ export default function WebGlComponent() {
   }, []);
 
   function createFirstLayer(w: number, h: number) {
-    if (!textureRef.current || !appRef.current || !maskContainerRef.current)
-      return;
+    if (!textureRef.current || !appRef.current) return;
 
     const layer = new Container();
     layer.label = `defaultImageLayer`;
@@ -190,6 +188,7 @@ export default function WebGlComponent() {
       const source = new ImageSource({ resource: img });
       const texture = new Texture({ source });
       const overlay = new Container();
+      overlay.label = "overlayContainer";
       const hoverGraph = new Graphics();
 
       textureRef.current = texture;
@@ -204,10 +203,8 @@ export default function WebGlComponent() {
 
       if (prevStage) appRef.current.stage.removeChild(prevStage);
       appRef.current.stage.addChild(renderSprite);
-      appRef.current.stage.addChild(overlay);
-
-      const maskContainer = new Container();
-      maskContainer.label = "maskContainer";
+      if (!appRef.current.stage.getChildByLabel("overlayContainer"))
+        appRef.current.stage.addChild(overlay);
 
       image = useSessionStore
         .getState()
@@ -221,7 +218,6 @@ export default function WebGlComponent() {
 
       const brush = new Graphics();
 
-      maskContainerRef.current = maskContainer;
       brushRef.current = brush;
 
       spriteRef.current = renderSprite;
@@ -281,11 +277,10 @@ export default function WebGlComponent() {
     }
   }, [expandMode, cropSaved]);
 
-  function applyFilters() {
+  function applyFilters(startIndex = 0) {
     if (!appRef.current) return;
 
     const imageFilter = image?.filter;
-    let imageMaskLayers = image?.renderTextures;
 
     if (spriteRef.current && imageFilter && haldSprite) {
       spriteRef.current.filters = lutFilter
@@ -300,15 +295,23 @@ export default function WebGlComponent() {
       image.renderTextures.length > 0 &&
       spriteRef.current
     ) {
-      let input = textureRef.current ?? spriteRef.current.texture;
+      let input =
+        startIndex === 0
+          ? textureRef.current
+          : image.renderTextures[startIndex - 1].resultTexture;
 
-      imageMaskLayers?.forEach((layer) => {
+      const layers = image.renderTextures;
+
+      for (let i = startIndex; i < layers.length; i++) {
+        const layer = image.renderTextures[i];
+
         if (spriteRef.current) {
           renderSpriteRef.current.texture = input;
 
           if (layer.filter && appRef.current) {
-            renderSpriteRef.current.filters = [layer.filter];
+            layer.haldSprite.filters = [layer.filterMask];
             layer.filter.resources.layer_mask = layer.maskTexture.source;
+            renderSpriteRef.current.filters = [layer.filter];
 
             appRef.current.renderer.render({
               container: renderSpriteRef.current,
@@ -319,7 +322,7 @@ export default function WebGlComponent() {
             input = layer.resultTexture;
           }
         }
-      });
+      }
 
       spriteRef.current.texture = input;
       spriteRef.current.filters = [];
@@ -616,11 +619,7 @@ export default function WebGlComponent() {
     layers,
   ]);
 
-  useEffect(()=>{
-    applyFilters();
-  },[
-    isDrawing
-  ])
+  applyFilters();
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/frontend/handlers/filters/allFiltersFragment.ts
+++ b/src/frontend/handlers/filters/allFiltersFragment.ts
@@ -58,7 +58,7 @@ export const allFiltersFragment = `#version 300 es
     }
 
     void main() {
-    vec4 color = texture(prev_result, vTextureCoord);
+    vec4 color = texture(uTexture, vTextureCoord);
 
     vec3 rgb = color.rgb;
 
@@ -74,7 +74,7 @@ export const allFiltersFragment = `#version 300 es
     vec4 current = vec4(rgb, color.a);
 
     vec4 previous = texture(prev_result, vTextureCoord);
-    float layer_mask_float = texture(layer_mask, vTextureCoord).r;
+    float layer_mask_float = texture(layer_mask, vTextureCoord).a;
 
     finalColor = mix(previous, current, layer_mask_float);
     }

--- a/src/frontend/handlers/filters/allFiltersFragment.ts
+++ b/src/frontend/handlers/filters/allFiltersFragment.ts
@@ -38,7 +38,6 @@ export const allFiltersFragment = `#version 300 es
     
     out vec4 finalColor;
 
-    uniform sampler2D prev_result;
     uniform sampler2D layer_mask;
 
     vec3 rgbToHsv(vec3 color) {
@@ -58,9 +57,9 @@ export const allFiltersFragment = `#version 300 es
     }
 
     void main() {
-    vec4 color = texture(uTexture, vTextureCoord);
+    vec4 current = texture(uTexture, vTextureCoord);
 
-    vec3 rgb = color.rgb;
+    vec3 rgb = current.rgb;
 
     ${temperatureFragment}
     ${channelMixerFragment}
@@ -71,11 +70,10 @@ export const allFiltersFragment = `#version 300 es
 
     rgb = clamp(rgb, 0.0, 1.0);
 
-    vec4 current = vec4(rgb, color.a);
+    vec4 filtered = vec4(rgb, current.a);
 
-    vec4 previous = texture(prev_result, vTextureCoord);
-    float layer_mask_float = texture(layer_mask, vTextureCoord).a;
+    float lm = texture(layer_mask, vTextureCoord).a;
 
-    finalColor = mix(previous, current, layer_mask_float);
+    finalColor = mix(current, filtered, lm);
     }
 `;

--- a/src/frontend/handlers/filters/allFiltersFragment.ts
+++ b/src/frontend/handlers/filters/allFiltersFragment.ts
@@ -38,6 +38,8 @@ export const allFiltersFragment = `#version 300 es
     
     out vec4 finalColor;
 
+    uniform sampler2D prev_result;
+    uniform sampler2D layer_mask;
 
     vec3 rgbToHsv(vec3 color) {
       vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
@@ -56,7 +58,7 @@ export const allFiltersFragment = `#version 300 es
     }
 
     void main() {
-    vec4 color = texture(uTexture, vTextureCoord);    
+    vec4 color = texture(prev_result, vTextureCoord);
 
     vec3 rgb = color.rgb;
 
@@ -69,6 +71,11 @@ export const allFiltersFragment = `#version 300 es
 
     rgb = clamp(rgb, 0.0, 1.0);
 
-    finalColor = vec4(rgb, color.a);
+    vec4 current = vec4(rgb, color.a);
+
+    vec4 previous = texture(prev_result, vTextureCoord);
+    float layer_mask_float = texture(layer_mask, vTextureCoord).r;
+
+    finalColor = mix(previous, current, layer_mask_float);
     }
 `;

--- a/src/frontend/handlers/filters/maskFiltersFragment.ts
+++ b/src/frontend/handlers/filters/maskFiltersFragment.ts
@@ -1,0 +1,75 @@
+import { brightnessExposureContrastFragment } from "./brightnessExposureContrastFragment";
+import { channelMixerFragment } from "./channelMixerFragment";
+import { hueFragment } from "./hueFragment";
+import { levelsFragment } from "./levels";
+import { temperatureFragment } from "./temperatureFragment";
+import { vibranceFragment } from "./vibranceFragment";
+
+export const maskFiltersFragment = `#version 300 es
+    precision highp float;
+
+    in vec2 vTextureCoord; 
+    uniform sampler2D uTexture;
+    
+    uniform float exposure_input;
+    uniform float brightness_input;
+    uniform float contrast_input;
+
+    uniform float temperature_input;
+    uniform float tint_input;
+
+    uniform float hue_input;
+    uniform float saturation_input;
+    uniform float value_input;
+
+    uniform float black_input;
+    uniform float gamma_input;
+    uniform float white_input;
+    uniform float outblack_input;
+    uniform float outwhite_input;
+
+    uniform mat3 channel_colorMatrix_input;
+    uniform vec3 channel_offset_input;
+
+    uniform float vibrance_input; 
+
+    float originalLuminance;
+    float currentLuminance;
+    
+    out vec4 finalColor;
+
+    vec3 rgbToHsv(vec3 color) {
+      vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+      vec4 maxBG = mix(vec4(color.bg, K.wz), vec4(color.gb, K.xy), step(color.b, color.g));
+      vec4 maxPR = mix(vec4(maxBG.xyw, color.r), vec4(color.r, maxBG.yzx), step(maxBG.x, color.r));
+      float saturation = maxPR.x - min(maxPR.w, maxPR.y);
+      float e = 1.0e-10;
+      return vec3(abs(maxPR.z + (maxPR.w - maxPR.y) / (6.0 * saturation + e)), saturation / (maxPR.x + e), maxPR.x);
+    }
+
+    vec3 hsvToRgb(vec3 c) {
+      vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+      vec3 p = fract(c.xxx + K.xyz) * 6.0 - K.www;
+      vec3 rgb = c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
+      return rgb;
+    }
+
+    void main() {
+    vec4 current = texture(uTexture, vTextureCoord);
+
+    vec3 rgb = current.rgb;
+
+    ${temperatureFragment}
+    ${channelMixerFragment}
+    ${brightnessExposureContrastFragment}
+    ${levelsFragment}
+    ${vibranceFragment}
+    ${hueFragment}
+
+    rgb = clamp(rgb, 0.0, 1.0);
+
+    vec4 filtered = vec4(rgb, current.a);
+
+    finalColor = filtered;
+    }
+`;

--- a/src/frontend/helper/mask/applyFilters.ts
+++ b/src/frontend/helper/mask/applyFilters.ts
@@ -1,0 +1,77 @@
+import { CustomImage } from "@/interfaces/interface";
+import { Application, Sprite, Texture } from "pixi.js";
+import { RefObject } from "react";
+
+export interface applyFiltersProps {
+  startIndex?: number;
+  image: CustomImage | undefined;
+  spriteRef: RefObject<Sprite | null>;
+  appRef: RefObject<Application | null>;
+  textureRef: RefObject<Texture | null>;
+  renderSpriteRef: RefObject<Sprite | null>;
+}
+
+export function applyFilters(props: applyFiltersProps) {
+  const startIndex = props.startIndex ? props.startIndex : 0;
+  const image = props.image;
+  const lutFilter = image?.lutFilter;
+  const haldSprite = image?.haldSprite;
+  const spriteRef = props.spriteRef;
+  const appRef = props.appRef;
+  const textureRef = props.textureRef;
+  const renderSpriteRef = props.renderSpriteRef.current;
+
+  if (!appRef.current) return;
+
+  const imageFilter = image?.filter;
+
+  if (spriteRef.current && imageFilter && haldSprite) {
+    spriteRef.current.filters = lutFilter
+      ? [lutFilter, imageFilter]
+      : [imageFilter];
+    haldSprite.filters = lutFilter ? [lutFilter, imageFilter] : [imageFilter];
+  }
+
+  if (
+    image &&
+    image.renderTextures &&
+    image.renderTextures.length > 0 &&
+    spriteRef.current
+  ) {
+    let input =
+      startIndex === 0
+        ? textureRef.current
+        : image.renderTextures[startIndex - 1].resultTexture;
+
+    const layers = image.renderTextures;
+
+    for (let i = startIndex; i < layers.length; i++) {
+      const layer = image.renderTextures[i];
+
+      if (spriteRef.current && renderSpriteRef) {
+        renderSpriteRef.texture = input;
+
+        if (layer.filter && appRef.current) {
+          if (layer.filter.resources.layer_mask !== layer.maskTexture.source)
+            layer.filter.resources.layer_mask = layer.maskTexture.source;
+
+          layer.haldSprite.filters = [layer.filterMask];
+          renderSpriteRef.filters = [layer.filter];
+
+
+          appRef.current.renderer.render({
+            container: renderSpriteRef,
+            target: layer.resultTexture,
+            clear: true,
+          });
+
+
+          input = layer.resultTexture;
+        }
+      }
+    }
+
+    spriteRef.current.texture = input;
+    spriteRef.current.filters = [];
+  }
+}

--- a/src/frontend/helper/mask/createMask.ts
+++ b/src/frontend/helper/mask/createMask.ts
@@ -1,8 +1,6 @@
 import { MasksProps } from "@/interfaces/mask.interface";
 import {
   Application,
-  Container,
-  ContainerChild,
   FillGradient,
   Filter,
   Graphics,
@@ -12,9 +10,16 @@ import {
   Texture,
   TextureSource,
 } from "pixi.js";
-import { Dispatch, RefObject, SetStateAction, useEffect } from "react";
+import {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useCallback,
+  useEffect,
+} from "react";
 import { drawLine } from "./drawLine";
-import { MasksLayers } from "@/interfaces/interface";
+import { CustomImage, MasksLayers } from "@/interfaces/interface";
+import { applyFilters } from "./applyFilters";
 
 interface createMaskProps {
   appRef: RefObject<Application<Renderer> | null>;
@@ -24,7 +29,6 @@ interface createMaskProps {
   lastX: RefObject<number | null>;
   brushSize: number;
   hoverMaskGraphRef: RefObject<Graphics>;
-  masks: MasksProps[] | undefined;
   selectedImg: number;
   maskErase: boolean;
   brushRef: RefObject<Graphics | null>;
@@ -34,13 +38,20 @@ interface createMaskProps {
   scale: number;
   spriteRef: RefObject<Sprite | null>;
   webglFilterRef: RefObject<Filter | null>;
-  renderTextures: MasksLayers[] | undefined;
   textureRef: RefObject<Texture<TextureSource<any>> | null>;
+  image: CustomImage | undefined;
 }
 
 export const createMask = (props: createMaskProps) => {
+  const image = props.image;
+  if (!image) return;
+
   const appRef = props.appRef;
+  const spriteRef = props.spriteRef;
+  const renderSpriteRef = props.spriteRef;
   const hoverMaskGraphRef = props.hoverMaskGraphRef;
+  const textureRef = props.textureRef;
+
   const selectedImg = props.selectedImg;
   const maskErase = props.maskErase;
   const brushRef = props.brushRef.current;
@@ -49,7 +60,9 @@ export const createMask = (props: createMaskProps) => {
   const selectedLayer = props.selectedLayer ?? null;
   const scale = props.scale ?? 1;
   const brushSize = props.brushSize;
-  const renderTextures = props.renderTextures;
+  const isDrawing = props.isDrawing;
+
+  const renderTextures = image.renderTextures;
   const layer = renderTextures?.find((rt) => rt.id === selectedLayer);
 
   const gradient = new FillGradient({
@@ -138,6 +151,8 @@ export const createMask = (props: createMaskProps) => {
 
     if (selectedLayer !== null) paint(localPos.x, localPos.y);
   });
+
+ 
 
   useEffect(() => {
     hoverMaskGraphRef.current.clear();

--- a/src/frontend/helper/mask/createMask.ts
+++ b/src/frontend/helper/mask/createMask.ts
@@ -1,4 +1,4 @@
-import { MasksProps, RenderLayer } from "@/interfaces/mask.interface";
+import { MasksProps } from "@/interfaces/mask.interface";
 import {
   Application,
   Container,
@@ -9,6 +9,8 @@ import {
   Renderer,
   RenderTexture,
   Sprite,
+  Texture,
+  TextureSource,
 } from "pixi.js";
 import { Dispatch, RefObject, SetStateAction, useEffect } from "react";
 import { drawLine } from "./drawLine";
@@ -25,7 +27,6 @@ interface createMaskProps {
   masks: MasksProps[] | undefined;
   selectedImg: number;
   maskErase: boolean;
-  maskContainer: Container<ContainerChild> | null;
   brushRef: RefObject<Graphics | null>;
   maskTextureRef: RefObject<RenderTexture | null>;
   sharpness: number;
@@ -34,6 +35,7 @@ interface createMaskProps {
   spriteRef: RefObject<Sprite | null>;
   webglFilterRef: RefObject<Filter | null>;
   renderTextures: MasksLayers[] | undefined;
+  textureRef: RefObject<Texture<TextureSource<any>> | null>;
 }
 
 export const createMask = (props: createMaskProps) => {
@@ -47,6 +49,8 @@ export const createMask = (props: createMaskProps) => {
   const selectedLayer = props.selectedLayer ?? null;
   const scale = props.scale ?? 1;
   const brushSize = props.brushSize;
+  const renderTextures = props.renderTextures;
+  const layer = renderTextures?.find((rt) => rt.id === selectedLayer);
 
   const gradient = new FillGradient({
     type: "radial",
@@ -78,6 +82,9 @@ export const createMask = (props: createMaskProps) => {
     }
 
     if (appRef.current && renderTexture && brushRef) {
+      const renderTexture =
+        renderTextures && renderTextures[selectedLayer].maskTexture;
+
       appRef.current.renderer.render({
         container: brushRef,
         target: renderTexture,
@@ -109,6 +116,9 @@ export const createMask = (props: createMaskProps) => {
 
     props.lastX.current = x;
     props.lastY.current = y;
+
+    if (layer && layer.filter)
+      layer.filter.resources.layer_mask = props.maskTextureRef.current?.source;
   });
 
   appRef.current?.stage.on("pointerup", () => {

--- a/src/frontend/helper/mask/createMask.ts
+++ b/src/frontend/helper/mask/createMask.ts
@@ -4,6 +4,7 @@ import {
   Container,
   ContainerChild,
   FillGradient,
+  Filter,
   Graphics,
   Renderer,
   RenderTexture,
@@ -11,6 +12,7 @@ import {
 } from "pixi.js";
 import { Dispatch, RefObject, SetStateAction, useEffect } from "react";
 import { drawLine } from "./drawLine";
+import { MasksLayers } from "@/interfaces/interface";
 
 interface createMaskProps {
   appRef: RefObject<Application<Renderer> | null>;
@@ -30,6 +32,8 @@ interface createMaskProps {
   selectedLayer: number | null;
   scale: number;
   spriteRef: RefObject<Sprite | null>;
+  webglFilterRef: RefObject<Filter | null>;
+  renderTextures: MasksLayers[] | undefined;
 }
 
 export const createMask = (props: createMaskProps) => {
@@ -39,6 +43,8 @@ export const createMask = (props: createMaskProps) => {
   const maskErase = props.maskErase;
   const brushRef = props.brushRef.current;
   const renderTexture = props.renderTextureRef.current;
+  const renderTextures = props.renderTextures;
+  const webglFilterRef = props.webglFilterRef.current;
   const sharpness = props.sharpness ?? 0;
   const selectedLayer = props.selectedLayer ?? null;
   const scale = props.scale ?? 1;

--- a/src/frontend/helper/mask/createMask.ts
+++ b/src/frontend/helper/mask/createMask.ts
@@ -27,7 +27,7 @@ interface createMaskProps {
   maskErase: boolean;
   maskContainer: Container<ContainerChild> | null;
   brushRef: RefObject<Graphics | null>;
-  renderTextureRef: RefObject<RenderTexture | null>;
+  maskTextureRef: RefObject<RenderTexture | null>;
   sharpness: number;
   selectedLayer: number | null;
   scale: number;
@@ -42,9 +42,7 @@ export const createMask = (props: createMaskProps) => {
   const selectedImg = props.selectedImg;
   const maskErase = props.maskErase;
   const brushRef = props.brushRef.current;
-  const renderTexture = props.renderTextureRef.current;
-  const renderTextures = props.renderTextures;
-  const webglFilterRef = props.webglFilterRef.current;
+  const renderTexture = props.maskTextureRef.current;
   const sharpness = props.sharpness ?? 0;
   const selectedLayer = props.selectedLayer ?? null;
   const scale = props.scale ?? 1;

--- a/src/frontend/helper/mask/createMask.ts
+++ b/src/frontend/helper/mask/createMask.ts
@@ -59,7 +59,7 @@ export const createMask = (props: createMaskProps) => {
     colorStops: [
       { offset: 0, color: "rgba(255,255,255,1)" },
       { offset: sharpness, color: "#fff" },
-      { offset: 1, color: "rgba(255,0,0,0)" },
+      { offset: 1, color: "rgba(255,255,255,0)" },
     ],
     textureSpace: "local",
   });

--- a/src/frontend/interfaces/interface.ts
+++ b/src/frontend/interfaces/interface.ts
@@ -117,6 +117,7 @@ export interface MasksLayers {
   renderSprite: Sprite | any;
   filter: Filter | null;
   filters?: FilterProps;
+  filterMask: Filter | null;
 }
 //#endregion
 
@@ -393,7 +394,8 @@ export interface SessionStore {
     maskTexture: RenderTexture,
     filter: Filter,
     resultTexture: any,
-    renderSprite: Sprite
+    renderSprite: Sprite,
+    filterMask: Filter,
   ) => void;
   //#endregion
 }
@@ -499,7 +501,6 @@ export interface WorkSessionContextProps {
   setMaskBrushSize: Dispatch<SetStateAction<number>>;
   maskTextureRef: RefObject<RenderTexture | null>;
   brushRef: RefObject<Graphics | null>;
-  maskContainerRef: RefObject<Container<ContainerChild> | null>;
   maskSharpness: number;
   setMaskSharpness: Dispatch<SetStateAction<number>>;
   selectedLayer: number | null;

--- a/src/frontend/interfaces/interface.ts
+++ b/src/frontend/interfaces/interface.ts
@@ -111,10 +111,10 @@ export interface ExportSettings {
 //#region MasksLayers
 export interface MasksLayers {
   id: number;
-  mask: RenderTexture;
-  sprite: Sprite | any;
-  imageSprite: Sprite | any;
+  maskTexture: RenderTexture;
+  resultTexture: RenderTexture | any;
   haldSprite: Sprite | any;
+  renderSprite: Sprite | any;
   filter: Filter | null;
   filters?: FilterProps;
 }
@@ -390,10 +390,10 @@ export interface SessionStore {
   //#region Masks
   addNewRenderTexture: (
     id: number,
-    renderTexture: RenderTexture,
-    outputSprite: Sprite,
-    imageSprite: Sprite,
-    filter?: Filter,
+    maskTexture: RenderTexture,
+    filter: Filter,
+    resultTexture: any,
+    renderSprite: Sprite
   ) => void;
   //#endregion
 }
@@ -497,7 +497,7 @@ export interface WorkSessionContextProps {
   setMaskEraseMode: Dispatch<SetStateAction<boolean>>;
   maskBrushSize: number;
   setMaskBrushSize: Dispatch<SetStateAction<number>>;
-  renderTextureRef: RefObject<RenderTexture | null>;
+  maskTextureRef: RefObject<RenderTexture | null>;
   brushRef: RefObject<Graphics | null>;
   maskContainerRef: RefObject<Container<ContainerChild> | null>;
   maskSharpness: number;
@@ -505,6 +505,9 @@ export interface WorkSessionContextProps {
   selectedLayer: number | null;
   setSelectLayer: Dispatch<SetStateAction<number | null>>;
   selectedLayerRef: RefObject<Sprite | null>;
+  renderSpriteRef: RefObject<Sprite>;
+  isDrawing: boolean;
+  setIsDrawing: Dispatch<SetStateAction<boolean>>;
 }
 //#endregion
 

--- a/src/frontend/interfaces/interface.ts
+++ b/src/frontend/interfaces/interface.ts
@@ -222,6 +222,7 @@ export interface SessionStore {
     captionSamples?: string[] | undefined,
   ) => void;
   setRenderTexture: (id: number, renderTexture: RenderTexture) => void;
+   setFilter: (id: number, filter: Filter) => void;
   //#endregion
 
   //#region LAYER

--- a/src/frontend/interfaces/interface.ts
+++ b/src/frontend/interfaces/interface.ts
@@ -221,12 +221,13 @@ export interface SessionStore {
     exifData?: string[] | undefined,
     captionSamples?: string[] | undefined,
   ) => void;
+  setRenderTexture: (id: number, renderTexture: RenderTexture) => void;
   //#endregion
 
   //#region LAYER
-  deleteLayer: (id: number, layerId: number) => void
-//#endregion
-  
+  deleteLayer: (id: number, layerId: number) => void;
+  //#endregion
+
   //#region MÉRETEK
   setImageSize: (id: number, width: number, height: number) => void;
   setCropBox: ({ id, box }: { id: number; box: CropBox }) => void;
@@ -363,9 +364,18 @@ export interface SessionStore {
   //#endregion
 
   //#region FILTERS
-  editFilters: (id: number, filterName: string, value: string | number, selectedLayer?: number | null) => void;
-  getFilterValue: (id: number, filterName:  keyof FilterProps, selectedLayer?: number | null) => number | undefined;
-  getFilters: (id: number,  layerId?: number) => FilterProps;
+  editFilters: (
+    id: number,
+    filterName: string,
+    value: string | number,
+    selectedLayer?: number | null,
+  ) => void;
+  getFilterValue: (
+    id: number,
+    filterName: keyof FilterProps,
+    selectedLayer?: number | null,
+  ) => number | undefined;
+  getFilters: (id: number, layerId?: number) => FilterProps;
   //#endregion
 
   //#region LUT
@@ -377,7 +387,13 @@ export interface SessionStore {
   //#endregion
 
   //#region Masks
-  addNewRenderTexture: (id: number, renderTexture: RenderTexture, outputSprite: Sprite, imageSprite: Sprite, filter?: Filter) => void;
+  addNewRenderTexture: (
+    id: number,
+    renderTexture: RenderTexture,
+    outputSprite: Sprite,
+    imageSprite: Sprite,
+    filter?: Filter,
+  ) => void;
   //#endregion
 }
 //#endregion

--- a/src/frontend/interfaces/mask.interface.ts
+++ b/src/frontend/interfaces/mask.interface.ts
@@ -17,7 +17,6 @@ export interface MasksProps {
 }
 
 export interface RenderLayer {
-  imageSprite: Sprite;
   maskSprite: Sprite;
   maskTexture: RenderTexture;
   filter: Filter;

--- a/src/frontend/providers/sessionprovider.tsx
+++ b/src/frontend/providers/sessionprovider.tsx
@@ -55,7 +55,6 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
   const [selectedLayer, setSelectLayer] = useState<number | null>(0);
   const maskTextureRef = useRef<RenderTexture | null>(null);
   const brushRef = useRef<Graphics | null>(null);
-  const maskContainerRef = useRef<Container | null>(null);
   const selectedLayerRef = useRef<Sprite | null>(null);
 
   const [maskErase, setMaskEraseMode] = useState<boolean>(false);
@@ -115,7 +114,6 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
       setMaskBrushSize,
       maskTextureRef,
       brushRef,
-      maskContainerRef,
       maskSharpness,
       setMaskSharpness,
       selectedLayer,
@@ -151,7 +149,6 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
       maskBrushSize,
       maskTextureRef,
       brushRef,
-      maskContainerRef,
       maskSharpness,
       selectedLayer,
       selectedLayerRef,

--- a/src/frontend/providers/sessionprovider.tsx
+++ b/src/frontend/providers/sessionprovider.tsx
@@ -50,9 +50,10 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
   const webglFilterRef = useRef<Filter | null>(null);
   const lutFilterRef = useRef<ColorMapFilter | null>(null);
   const overlayRef = useRef<Container | null>(null);
+  const renderSpriteRef = useRef(new Sprite());
 
   const [selectedLayer, setSelectLayer] = useState<number | null>(0);
-  const renderTextureRef = useRef<RenderTexture | null>(null);
+  const maskTextureRef = useRef<RenderTexture | null>(null);
   const brushRef = useRef<Graphics | null>(null);
   const maskContainerRef = useRef<Container | null>(null);
   const selectedLayerRef = useRef<Sprite | null>(null);
@@ -60,6 +61,7 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
   const [maskErase, setMaskEraseMode] = useState<boolean>(false);
   const [maskBrushSize, setMaskBrushSize] = useState<number>(20);
   const [maskSharpness, setMaskSharpness] = useState<number>(0);
+  const [isDrawing, setIsDrawing] = useState<boolean>(false);
 
   const hoverGraph = new Graphics();
   const hoverMaskGraphRef = useRef<Graphics>(hoverGraph);
@@ -111,7 +113,7 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
       setMaskEraseMode,
       maskBrushSize,
       setMaskBrushSize,
-      renderTextureRef,
+      maskTextureRef,
       brushRef,
       maskContainerRef,
       maskSharpness,
@@ -119,6 +121,9 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
       selectedLayer,
       setSelectLayer,
       selectedLayerRef,
+      renderSpriteRef,
+      isDrawing,
+      setIsDrawing
     }),
     [
       step,
@@ -144,12 +149,14 @@ export function WorkSessionProvider({ children }: WorkSessionProviderProps) {
       hoverMaskGraphRef,
       maskErase,
       maskBrushSize,
-      renderTextureRef,
+      maskTextureRef,
       brushRef,
       maskContainerRef,
       maskSharpness,
       selectedLayer,
       selectedLayerRef,
+      renderSpriteRef,
+      isDrawing,
     ],
   );
 

--- a/src/frontend/stores/sessionData.ts
+++ b/src/frontend/stores/sessionData.ts
@@ -50,48 +50,6 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
         const haldTexture = Texture.from(hald);
         const haldSprite = new Sprite(haldTexture);
 
-        const channelOffset = getChannelOffsets(filters);
-
-        const filterUniforms = new UniformGroup({
-          exposure_input: { value: filters.exposure / 5.0, type: "f32" },
-          brightness_input: { value: filters.brightness / 100.0, type: "f32" },
-          contrast_input: {
-            value: (filters.contrast / 100.0) * 0.5 + 1.0,
-            type: "f32",
-          },
-          temperature_input: {
-            value: filters.temperature / 100.0,
-            type: "f32",
-          },
-          tint_input: { value: filters.tint / 100.0, type: "f32" },
-          saturation_input: { value: filters.saturation, type: "f32" },
-          hue_input: { value: filters.hue / 180.0, type: "f32" },
-          value_input: { value: filters.value, type: "f32" },
-          black_input: { value: filters.black / 255.0, type: "f32" },
-          white_input: { value: filters.white / 255.0, type: "f32" },
-          outblack_input: { value: filters.outblack / 255.0, type: "f32" },
-          outwhite_input: { value: filters.outwhite / 255.0, type: "f32" },
-          gamma_input: { value: filters.gamma, type: "f32" },
-          channel_colorMatrix_input: {
-            value: channelOffset.channels,
-            type: "mat3x3<f32>",
-          },
-          channel_offset_input: {
-            value: channelOffset.offset,
-            type: "vec3<f32>",
-          },
-          vibrance_input: { value: filters.vibrance / 100.0, type: "f32" },
-        });
-
-        const filter = Filter.from({
-          gl: {
-            fragment: allFiltersFragment,
-            vertex: defaultFilterVert,
-          },
-          resources: {
-            filterUniforms: filterUniforms,
-          },
-        });
 
         const sessionData = {
           id: nextId,
@@ -114,7 +72,7 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
           masks: [],
           renderTextures: [],
           renderTexture: null,
-          filter: filter,
+          filter: null,
           filters: filters,
           sprite: null,
         } as CustomImage;
@@ -167,6 +125,18 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
           return {
             ...image,
             renderTexture: renderTexture,
+          };
+        }),
+      }));
+    },
+    setFilter: (id: number, filter: Filter) => {
+      set((state) => ({
+        sessionData: state.sessionData.map((image) => {
+          if (image.id !== id) return image;
+
+          return {
+            ...image,
+            filter: filter,
           };
         }),
       }));

--- a/src/frontend/stores/sessionData.ts
+++ b/src/frontend/stores/sessionData.ts
@@ -50,7 +50,6 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
         const haldTexture = Texture.from(hald);
         const haldSprite = new Sprite(haldTexture);
 
-
         const sessionData = {
           id: nextId,
           blob: blob,
@@ -83,10 +82,10 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
       }),
     addNewRenderTexture: (
       id: number,
-      renderTexture: RenderTexture,
-      outputSprite: Sprite,
-      imageSprite: Sprite,
-      filter?: Filter,
+      maskTexture: RenderTexture,
+      filter: Filter,
+      resultTexture: RenderTexture,
+      renderSprite: any,
     ) => {
       set((state) => ({
         sessionData: state.sessionData.map((image) => {
@@ -101,10 +100,10 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
           const prevTextures = image.renderTextures ?? [];
           const currentText = {
             id: prevTextures.length,
-            mask: renderTexture,
-            sprite: outputSprite,
-            imageSprite,
+            maskTexture,
+            resultTexture,
             haldSprite,
+            renderSprite,
             filter: null,
           } as MasksLayers;
 

--- a/src/frontend/stores/sessionData.ts
+++ b/src/frontend/stores/sessionData.ts
@@ -113,6 +113,7 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
           haldSprite: haldSprite,
           masks: [],
           renderTextures: [],
+          renderTexture: null,
           filter: filter,
           filters: filters,
           sprite: null,
@@ -154,6 +155,18 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
           return {
             ...image,
             renderTextures: [...prevTextures, currentText],
+          };
+        }),
+      }));
+    },
+    setRenderTexture: (id: number, renderTexture: RenderTexture) => {
+      set((state) => ({
+        sessionData: state.sessionData.map((image) => {
+          if (image.id !== id) return image;
+
+          return {
+            ...image,
+            renderTexture: renderTexture,
           };
         }),
       }));

--- a/src/frontend/stores/sessionData.ts
+++ b/src/frontend/stores/sessionData.ts
@@ -11,21 +11,12 @@ import {
   YPositions,
 } from "@/interfaces/interface";
 import { ColorMapFilter } from "pixi-filters";
-import {
-  defaultFilterVert,
-  Filter,
-  RenderTexture,
-  Sprite,
-  Texture,
-  UniformGroup,
-} from "pixi.js";
+import { Filter, RenderTexture, Sprite, Texture } from "pixi.js";
 import { RefObject } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { immer } from "zustand/middleware/immer";
 import { createWithEqualityFn } from "zustand/traditional";
 import { getImageSize } from "@/helper/sizes/getImageSize";
-import { getChannelOffsets } from "@/helper/lut/getChannelOffset";
-import { allFiltersFragment } from "@/handlers/filters/allFiltersFragment";
 import { filters } from "@/interfaces/filters.interface";
 
 export const useSessionStore = createWithEqualityFn<SessionStore>()(
@@ -86,13 +77,13 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
       filter: Filter,
       resultTexture: RenderTexture,
       renderSprite: any,
+      filterMask: Filter,
     ) => {
       set((state) => ({
         sessionData: state.sessionData.map((image) => {
           if (image.id !== id) return image;
 
           const hald = generateHald(64);
-
           if (hald instanceof HTMLCanvasElement !== true) return null;
           const haldTexture = Texture.from(hald);
           const haldSprite = new Sprite(haldTexture);
@@ -105,9 +96,13 @@ export const useSessionStore = createWithEqualityFn<SessionStore>()(
             haldSprite,
             renderSprite,
             filter: null,
+            filterMask: null,
           } as MasksLayers;
 
           if (filter) currentText.filter = filter;
+          if (filterMask) currentText.filterMask = filterMask;
+
+          haldSprite.filters = filterMask;
 
           return {
             ...image,


### PR DESCRIPTION
Tickert használunk, mert ez azt csinálja hogy "tick"-enként (frissítési ciklusonként / framenként) futtatja a filter frissítését a megadott sprite-tól kezdve. Ez azért előnyös, mert mindig csak azokat az elemeket frissítjük, amelyeknek szükségük van rá. Ez performance szempontból jó, mert mikor rajzolunk, akkor alapból ha rajzoláshoz kötnénk az applyFilter()-t, akkor létrejönne mondjuk 1000 iteráció, viszont ezzel nem minden iterációkor futtatjuk le az applyFilter()-t, hanem minden egyes tick-nél

TODO: Optimalizálás, ha van még lehetőség rá, átnézés, illetve szerintem kicsit el van csúszva maga a rajzolás ezt megnézni